### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills using GitHub, part of the school's GitHub Certifications program",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
Fixes #6

Adds the missing GitHub Skills activity to the extracurricular activities list, as announced by the principal. Students can now find and register for it on the website.

**Changes:**
- Added "GitHub Skills" activity to `src/app.py` with description, schedule (Wednesdays 3:30–5:00 PM), and a max capacity of 25 students.